### PR TITLE
add copy file github action

### DIFF
--- a/.github/workflows/copy_file.yml
+++ b/.github/workflows/copy_file.yml
@@ -1,0 +1,26 @@
+name: copy_file
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  copy-file:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Pushes file
+      uses: dmnemec/copy_file_to_another_repo_action@main
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      with:
+        source_file: './documentation/data/website.yml'
+        destination_repo: 'GSTT-CSC/gstt-csc.github.io'
+        destination_folder: '_projects'
+        #email and username of the user associated with the token
+        user_email: ''
+        user_name: ''
+        commit_message: ''

--- a/documentation/data/website.yml
+++ b/documentation/data/website.yml
@@ -1,0 +1,11 @@
+statement_of_purpose: 'Purpose'
+
+device_name: DEVICE
+
+logo: path/to/logo
+
+MLFlow_artefacts:
+  - image: path/to/performance_image1.png
+    description: “text description”
+
+Dataset_size: X


### PR DESCRIPTION
added a GitHub action to copy a website.yml file to the website repo when project-template is pushed to master branch. The GitHub action needs the token and the associated user details to be filled in appropriately.